### PR TITLE
Song editor: Fix possible exception depending on clipboard content

### DIFF
--- a/WordsLive/Editor/EditorWindow.xaml.cs
+++ b/WordsLive/Editor/EditorWindow.xaml.cs
@@ -395,7 +395,7 @@ namespace WordsLive.Editor
 				{
 					string text = Clipboard.GetText();
 					var firstNewline = text.IndexOf('\n');
-					if (firstNewline > 0 && text.Length >= firstNewline + 1)
+					if (firstNewline > 0 && text.Length >= firstNewline + 2)
 					{
 						var next = text[firstNewline + 1];
 						e.CanExecute = (next == '\n' || next == '\r') && text.Contains("CCLI");


### PR DESCRIPTION
An exception can occur in the song editor window: copy some string with a trailing newline (`\n`) into your clipboard, click on e.g. the File menu. It is just an incorrect bounds check, so easy to fix.