### PR TITLE
Installer: Fix problem with missing Office libs in latest version

### DIFF
--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -31,6 +31,7 @@
 			<ComponentGroupRef Id="ThirdPartyAssemblies" />
 			<ComponentGroupRef Id="VlcDotNetAssemblies" />
 			<ComponentGroupRef Id="PowerpointViewerLibComponents" />
+			<ComponentGroupRef Id="OfficeLibComponents" />
 			<ComponentGroupRef Id="CefSharpX86Components" />
 			<ComponentGroupRef Id="CefSharpX86LocalesComponents" />
 			<ComponentGroupRef Id="DataComponents" />
@@ -148,6 +149,14 @@
 			</Component>
 			<Component>
 				<File Source="$(var.WordsLive.TargetDir)PowerpointViewerLib.dll" Name="PowerpointViewerLib.dll" KeyPath="yes" />
+			</Component>
+		</ComponentGroup>
+		<ComponentGroup Id="OfficeLibComponents" Directory="APPLICATIONFOLDER">
+			<Component>
+				<File Source="$(var.WordsLive.TargetDir)Office.dll" Name="Office.dll" KeyPath="yes" />
+			</Component>
+			<Component>
+				<File Source="$(var.WordsLive.TargetDir)Microsoft.Office.Interop.PowerPoint.dll" Name="Microsoft.Office.Interop.PowerPoint.dll" KeyPath="yes" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="CefSharpX86Components" Directory="APPLICATIONFOLDER">


### PR DESCRIPTION
When I build the installer locally, the produced artifact does not work: it complains about missing `Microsoft.Office.Interop.PowerPoint`. I checked with the latest release, actually I have the same problem there (when I uninstall WordsLive and reinstall it). Previously I did not have the issue, maybe because I only upgraded WordsLive. However, I'm a bit confused because earlier versions of WordsLive do not install that DLL as far as I can see, so not sure why I did not have problems earlier.

With the changes in this PR it works for me, but please have a closer look.