### PR TITLE
Song editor: Select all content in text fields with initial focus

### DIFF
--- a/WordsLive/Editor/RenamePartWindow.xaml
+++ b/WordsLive/Editor/RenamePartWindow.xaml
@@ -26,8 +26,7 @@
 		MinWidth="300" MaxWidth="500"
 		ShowInTaskbar="False"
 		WindowStartupLocation="CenterOwner" 
-		WindowStyle="SingleBorderWindow"
-		FocusManager.FocusedElement="{Binding ElementName=newNameTextBox}">
+		WindowStyle="SingleBorderWindow">
 	<DockPanel>
 		<Label HorizontalAlignment="Left" VerticalAlignment="Top" DockPanel.Dock="Top" Content="{x:Static resx:Resource.rpNewNameLabel}"/>
 		<TextBox x:Name="newNameTextBox" Height="Auto" Margin="5"  DockPanel.Dock="Top" Style="{StaticResource textBoxInError}">

--- a/WordsLive/Editor/RenamePartWindow.xaml.cs
+++ b/WordsLive/Editor/RenamePartWindow.xaml.cs
@@ -41,6 +41,12 @@ namespace WordsLive.Editor
 			{
 				this.PartName = this.part.Name;
 			}
+
+			this.Loaded += delegate
+			{
+				this.newNameTextBox.Focus();
+				this.newNameTextBox.SelectAll();
+			};
 		}
 		
 		public string PartName

--- a/WordsLive/Editor/RenameSongWindow.xaml
+++ b/WordsLive/Editor/RenameSongWindow.xaml
@@ -25,8 +25,7 @@
 		MinWidth="300" MaxWidth="500"
 		ShowInTaskbar="False"
 		WindowStartupLocation="CenterOwner" 
-		WindowStyle="SingleBorderWindow"
-		FocusManager.FocusedElement="{Binding ElementName=newNameTextBox}">
+		WindowStyle="SingleBorderWindow">
 	<StackPanel Orientation="Vertical">
 		<Label HorizontalAlignment="Left" VerticalAlignment="Top" Content="{x:Static resx:Resource.rsNewNameLabel}"/>
 		<TextBox x:Name="newNameTextBox" Height="Auto" Margin="5" Style="{StaticResource textBoxInError}">

--- a/WordsLive/Editor/RenameSongWindow.xaml.cs
+++ b/WordsLive/Editor/RenameSongWindow.xaml.cs
@@ -44,6 +44,12 @@ namespace WordsLive.Editor
             InitializeComponent();
             this.SongName = songName;
             this.DataContext = this;
+
+            this.Loaded += delegate
+            {
+                this.newNameTextBox.Focus();
+                this.newNameTextBox.SelectAll();
+            };
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/WordsLive/Editor/SaveFilenameDialog.xaml.cs
+++ b/WordsLive/Editor/SaveFilenameDialog.xaml.cs
@@ -35,6 +35,12 @@ namespace WordsLive.Editor
 
 			this.DataContext = this;
 			this.FilenameWithoutExtension = name;
+
+			this.Loaded += delegate
+			{
+				this.filenameTextBox.Focus();
+				this.filenameTextBox.SelectAll();
+			};
 		}
 
 		public string FilenameWithoutExtension


### PR DESCRIPTION
When changing the name of a song, a song part or saving a song there is a text field with initial focus. It already has content and the cursor position is in the very beginning. I think this is never what you really want, I would expect everything to be selected or (maybe) the cursor to be in the very end.

I suggest to modify behavior to select all content by default. (WPF and FocusManager do not seem to support this natively. I don't get it why such conventions in Windows applications are ignored by WPF...)

We could also change behavior for all text boxes when they get focus. One simple possibility may be https://madprops.org/blog/wpf-textbox-selectall-on-focus/, although it's not perfect (behavior on mouse click: you can see everything gets focus for a very short time and then the focus is set to the position of the click)