### PR TITLE
Embed interop types for Powerpoint, fixes #38

### DIFF
--- a/WordsLive.Slideshow.Powerpoint.Bridge/Properties/AssemblyInfo.cs
+++ b/WordsLive.Slideshow.Powerpoint.Bridge/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
+// Siehe auch Target "EmbedInteropTypes"
+[assembly: ImportedFromTypeLib("Microsoft.Office.Interop.PowerPoint")]
+
 // Allgemeine Informationen über eine Assembly werden über die folgenden 
 // Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
 // die mit einer Assembly verknüpft sind.

--- a/WordsLive.Slideshow.Powerpoint.Bridge/WordsLive.Slideshow.Powerpoint.Bridge.csproj
+++ b/WordsLive.Slideshow.Powerpoint.Bridge/WordsLive.Slideshow.Powerpoint.Bridge.csproj
@@ -87,4 +87,11 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="EmbedInteropTypes" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
+    <ItemGroup>
+      <ReferencePath Condition=" '%(FileName)' == 'Microsoft.Office.Interop.PowerPoint' ">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This change makes it explicit that the used Powerpoint types need to be embedded directly because it does not happen automatically anymore. See #38.

On a system without Powerpoint, I verified no exception happens anymore when e.g. adding a song into the portfolio.