### PR TITLE
Also search in translation for fulltext search

### DIFF
--- a/WordsLive.Core/Songs/Song.cs
+++ b/WordsLive.Core/Songs/Song.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -431,6 +430,32 @@ namespace WordsLive.Core.Songs
 			get
 			{
 				return string.Join("\n", Parts.Select(part => part.TextWithoutChords).ToArray());
+			}
+		}
+
+		/// <summary>
+		/// Gets the translation of all parts at once.
+		/// Changes to this property are not notified.
+		/// </summary>
+		[JsonIgnore]
+		public string Translation
+		{
+			get
+			{
+				return string.Join("\n", Parts.Select(part => part.Translation).ToArray());
+			}
+		}
+
+		/// <summary>
+		/// Gets the translation of all parts but with chords symbols removed.
+		/// Changes to this property are not notified.
+		/// </summary>
+		[JsonIgnore]
+		public string TranslationWithoutChords
+		{
+			get
+			{
+				return string.Join("\n", Parts.Select(part => part.TranslationWithoutChords).ToArray());
 			}
 		}
 

--- a/WordsLive.Core/Songs/SongPart.cs
+++ b/WordsLive.Core/Songs/SongPart.cs
@@ -91,6 +91,32 @@ namespace WordsLive.Core.Songs
 		}
 
 		/// <summary>
+		/// Gets the translation text of all slides in this part.
+		/// Changes to this property are not notified.
+		/// </summary>
+		[JsonIgnore]
+		public string Translation
+		{
+			get
+			{
+				return string.Join("\n", Slides.Select(slide => slide.Translation).ToArray());
+			}
+		}
+
+		/// <summary>
+		/// Gets the translation text of all slides in this part, but with chords removed.
+		/// Changes to this property are not notified.
+		/// </summary>
+		[JsonIgnore]
+		public string TranslationWithoutChords
+		{
+			get
+			{
+				return string.Join("\n", Slides.Select(slide => slide.TranslationWithoutChords).ToArray());
+			}
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="SongPart"/> class.
 		/// </summary>
 		/// <param name="root">The song this part belongs to.</param>

--- a/WordsLive.Core/Songs/Storage/SongData.cs
+++ b/WordsLive.Core/Songs/Storage/SongData.cs
@@ -31,6 +31,7 @@ namespace WordsLive.Core.Songs.Storage
 	public class SongData
 	{
 		private string searchText = null;
+		private string searchTranslation = null;
 		private string searchTitle = null;
 
 		/// <summary>
@@ -47,6 +48,11 @@ namespace WordsLive.Core.Songs.Storage
 		/// Gets or sets the text (without chords and without the translation).
 		/// </summary>
 		public string Text { get; set; }
+
+		/// <summary>
+		/// Gets or sets the translation text.
+		/// </summary>
+		public string Translation { get; set; }
 
 		/// <summary>
 		/// Gets or sets the copyright as a single line.
@@ -84,6 +90,20 @@ namespace WordsLive.Core.Songs.Storage
 				if (searchText == null)
 					searchText = NormalizeSearchString(Text);
 				return searchText;
+			}
+		}
+
+		/// <summary>
+		/// Gets the search translation text (with whitespaces and commas removed)
+		/// </summary>
+		[JsonIgnore]
+		public string SearchTranslation
+		{
+			get
+			{
+				if (searchTranslation == null)
+					searchTranslation = NormalizeSearchString(Translation);
+				return searchTranslation;
 			}
 		}
 
@@ -126,6 +146,7 @@ namespace WordsLive.Core.Songs.Storage
 				Title = song.Title,
 				Filename = Path.GetFileName(Uri.UnescapeDataString(song.Uri.Segments.Last())),
 				Text = song.TextWithoutChords,
+				Translation = song.TranslationWithoutChords,
 				Copyright = String.Join(" ", song.Copyright.Split('\n').Select(line => line.Trim())),
 				Sources = String.Join("; ", song.Sources),
 				Language = song.Language,

--- a/WordsLive.Core/Songs/Storage/SongStorage.cs
+++ b/WordsLive.Core/Songs/Storage/SongStorage.cs
@@ -61,10 +61,10 @@ namespace WordsLive.Core.Songs.Storage
 		/// Filters the songs using a full-text search.
 		/// </summary>
 		/// <param name="query">The query to use. This is case-insensitive.</param>
-		/// <returns>All songs whose text or title contains the query.</returns>
+		/// <returns>All songs whose text, translation, or title contains the query.</returns>
 		public virtual IEnumerable<SongData> WhereTextContains(string query)
 		{
-			return All().Where(d => d.SearchTitle.ContainsIgnoreCase(query) || d.SearchText.ContainsIgnoreCase(query));
+			return All().Where(d => d.SearchTitle.ContainsIgnoreCase(query) || d.SearchText.ContainsIgnoreCase(query) || d.SearchTranslation.ContainsIgnoreCase(query));
 		}
 
 		/// <summary>

--- a/WordsLive/Songs/SongFilter.cs
+++ b/WordsLive/Songs/SongFilter.cs
@@ -182,7 +182,7 @@ namespace WordsLive.Songs
 						return true;
 					}
 				}
-				if (!(song.SearchTitle.ContainsIgnoreCase(NormalizedKeyword) || (SearchInText && song.SearchText.ContainsIgnoreCase(NormalizedKeyword))))
+				if (!(song.SearchTitle.ContainsIgnoreCase(NormalizedKeyword) || (SearchInText && song.SearchText.ContainsIgnoreCase(NormalizedKeyword)) || (SearchInText && song.SearchTranslation.ContainsIgnoreCase(NormalizedKeyword))))
 				{
 					return false;
 				}


### PR DESCRIPTION
The current fulltext search in the song database does not look at translations. This change adjusts the fulltext search to do that.

I verified that songs without a translation do not pose a problem: the translation is just empty and it won't find anything there.