### PR TITLE
Fix PDF/XPS scaling by rendering pages individually

### DIFF
--- a/WordsLive/Documents/DocumentControlPanel.xaml.cs
+++ b/WordsLive/Documents/DocumentControlPanel.xaml.cs
@@ -31,7 +31,6 @@ namespace WordsLive.Documents
 		private IDocumentPresentation presentation;
 		private DocumentMedia media;
 		private ControlPanelLoadState loadState = ControlPanelLoadState.Loading;
-		private DocumentPageScale pageScale = DocumentPageScale.FitToWidth;
 
 		public DocumentControlPanel()
 		{
@@ -76,15 +75,15 @@ namespace WordsLive.Documents
 		{
 			get
 			{
-				return pageScale;
+				return media.PageScale;
 			}
 			set
 			{
-				if (pageScale != value)
+				if (media.PageScale != value)
 				{
-					pageScale = value;
+					media.PageScale = value;
 
-					presentation.PageScale = pageScale;
+					presentation.PageScale = value;
 
 					OnPropertyChanged("PageScale");
 					OnPropertyChanged("CurrentPage");

--- a/WordsLive/Documents/DocumentMedia.cs
+++ b/WordsLive/Documents/DocumentMedia.cs
@@ -17,14 +17,41 @@
  */
 
 using System;
+using System.Collections.Generic;
 using WordsLive.Core;
 
 namespace WordsLive.Documents
 {
 	public abstract class DocumentMedia : Media
 	{
-		public DocumentMedia(Uri uri) : base(uri) { }
+		private static readonly string PageScaleKey = "pageScale";
+
+		public DocumentMedia(Uri uri, Dictionary<string, string> options) : base(uri, options) { }
+
+		public override void Load()
+		{
+			pageScale = Options.ContainsKey(PageScaleKey) && Enum.TryParse(Options[PageScaleKey], out DocumentPageScale value) ? value : default;
+		}
 
 		public abstract IDocumentPresentation CreatePresentation();
+
+		private DocumentPageScale pageScale;
+
+		public DocumentPageScale PageScale
+		{
+			get
+			{
+				return pageScale;
+			}
+			set
+			{
+				if (value != pageScale)
+				{
+					pageScale = value;
+					Options[PageScaleKey] = pageScale.ToString();
+					OnOptionsChanged();
+				}
+			}
+		}
 	}
 }

--- a/WordsLive/Documents/DocumentPageScale.cs
+++ b/WordsLive/Documents/DocumentPageScale.cs
@@ -18,9 +18,19 @@
 
 namespace WordsLive.Documents
 {
+	/// <summary>
+	/// Represents the options for scaling of document pages when rendered.
+	/// </summary>
 	public enum DocumentPageScale
 	{
-		FitToWidth,
-		WholePage
+		/// <summary>
+		/// Scale the current page to fit completely into the presentation area (default).
+		/// </summary>
+		WholePage,
+
+		/// <summary>
+		/// Scale the current page to use the full width of the presentation area, scrolling may be needed to view the lower parts of the page. This is useful for documents with portrait orientation.
+		/// </summary>
+		FitToWidth
 	}
 }

--- a/WordsLive/Documents/PdfDocument.cs
+++ b/WordsLive/Documents/PdfDocument.cs
@@ -17,17 +17,13 @@
  */
 
 using System;
+using System.Collections.Generic;
 
 namespace WordsLive.Documents
 {
 	public class PdfDocument : DocumentMedia
 	{
-		public PdfDocument(Uri uri) : base(uri) { }
-
-		public override void Load()
-		{
-			// nothing to do
-		}
+		public PdfDocument(Uri uri, Dictionary<string, string> options) : base(uri, options) { }
 
 		public override IDocumentPresentation CreatePresentation()
 		{

--- a/WordsLive/Documents/PdfDocumentHandler.cs
+++ b/WordsLive/Documents/PdfDocumentHandler.cs
@@ -44,7 +44,7 @@ namespace WordsLive.Documents
 
 		public override Media Handle(Uri uri, Dictionary<string, string> options)
 		{
-			return new PdfDocument(uri);
+			return new PdfDocument(uri, options);
 		}
 	}
 }

--- a/WordsLive/Documents/PdfPresentation.cs
+++ b/WordsLive/Documents/PdfPresentation.cs
@@ -47,13 +47,12 @@ namespace WordsLive.Documents
 			UriMapDataSource.Instance.Add(uriKey, Document.Uri);
 			this.pageScale = Document.PageScale;
 
-			this.bridge = new PdfPresentationBridge("asset://urimap/" + uriKey);
+			this.bridge = new PdfPresentationBridge("asset://urimap/" + uriKey, pageScale, Properties.Settings.Default.DocumentPageTransition);
 			this.Control.Web.JavascriptObjectRepository.UnRegisterAll();
 			this.Control.Web.JavascriptObjectRepository.Register("bridge", bridge, true);
 			bridge.CallbackLoaded += () => {
 				this.Control.Dispatcher.BeginInvoke(new Action(() => {
 					IsLoaded = true;
-					ApplyPageScale();
 					OnDocumentLoaded();
 				}));
 			};

--- a/WordsLive/Documents/PdfPresentation.cs
+++ b/WordsLive/Documents/PdfPresentation.cs
@@ -45,6 +45,7 @@ namespace WordsLive.Documents
 
 
 			UriMapDataSource.Instance.Add(uriKey, Document.Uri);
+			this.pageScale = Document.PageScale;
 
 			this.bridge = new PdfPresentationBridge("asset://urimap/" + uriKey);
 			this.Control.Web.JavascriptObjectRepository.UnRegisterAll();

--- a/WordsLive/Documents/PdfPresentation.cs
+++ b/WordsLive/Documents/PdfPresentation.cs
@@ -52,6 +52,7 @@ namespace WordsLive.Documents
 			bridge.CallbackLoaded += () => {
 				this.Control.Dispatcher.BeginInvoke(new Action(() => {
 					IsLoaded = true;
+					ApplyPageScale();
 					OnDocumentLoaded();
 				}));
 			};
@@ -119,14 +120,7 @@ namespace WordsLive.Documents
 			set
 			{
 				pageScale = value;
-
-				if (IsLoaded)
-				{
-					if (pageScale == DocumentPageScale.FitToWidth)
-						this.Control.Web.GetMainFrame().ExecuteJavaScriptAsync("fitToWidth()");
-					else
-						this.Control.Web.GetMainFrame().ExecuteJavaScriptAsync("wholePage()");
-				}
+				ApplyPageScale();
 			}
 		}
 
@@ -165,6 +159,17 @@ namespace WordsLive.Documents
 			base.Close();
 
 			UriMapDataSource.Instance.Remove(uriKey);
+		}
+
+		private void ApplyPageScale()
+		{
+			if (!IsLoaded)
+				return;
+
+			if (pageScale == DocumentPageScale.FitToWidth)
+				this.Control.Web.GetMainFrame().ExecuteJavaScriptAsync("fitToWidth()");
+			else
+				this.Control.Web.GetMainFrame().ExecuteJavaScriptAsync("wholePage()");
 		}
 
 		public event EventHandler DocumentLoaded;

--- a/WordsLive/Documents/PdfPresentationBridge.cs
+++ b/WordsLive/Documents/PdfPresentationBridge.cs
@@ -25,15 +25,29 @@ namespace WordsLive.Documents
 		public event Action CallbackLoaded;
 
 		private string document;
+		private DocumentPageScale pageScale;
+		private int transitionDuration;
 
-		public PdfPresentationBridge(string document)
+		public PdfPresentationBridge(string document, DocumentPageScale pageScale, int transitionDuration)
 		{
 			this.document = document;
+			this.pageScale = pageScale;
+			this.transitionDuration = transitionDuration;
 		}
 
 		public string GetDocument()
 		{
 			return document;
+		}
+
+		public bool GetRenderWholePage()
+		{
+			return pageScale == DocumentPageScale.WholePage;
+		}
+
+		public int GetTransitionDuration()
+		{
+			return transitionDuration;
 		}
 
 		public void OnCallbackLoaded()

--- a/WordsLive/Documents/XpsDocument.cs
+++ b/WordsLive/Documents/XpsDocument.cs
@@ -17,6 +17,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xps = System.Windows.Xps.Packaging;
 
@@ -26,10 +27,12 @@ namespace WordsLive.Documents
 	{
 		public Xps.XpsDocument Document { get; private set; }
 
-		public XpsDocument(Uri uri) : base(uri) { }
+		public XpsDocument(Uri uri, Dictionary<string, string> options) : base(uri, options) { }
 
 		public override void Load()
 		{
+			base.Load();
+
 			if (!this.Uri.IsFile)
 				throw new NotImplementedException("Loading XPS document from remote URI not implemented yet.");
 

--- a/WordsLive/Documents/XpsDocumentHandler.cs
+++ b/WordsLive/Documents/XpsDocumentHandler.cs
@@ -44,7 +44,7 @@ namespace WordsLive.Documents
 
 		public override Media Handle(Uri uri, Dictionary<string, string> options)
 		{
-			return new XpsDocument(uri);
+			return new XpsDocument(uri, options);
 		}
 	}
 }

--- a/WordsLive/Documents/XpsPresentation.cs
+++ b/WordsLive/Documents/XpsPresentation.cs
@@ -39,6 +39,7 @@ namespace WordsLive.Documents
 		public void SetSourceDocument(XpsDocument doc)
 		{
 			this.Control.Document = doc.Document.GetFixedDocumentSequence();
+			this.pageScale = doc.PageScale;
 			ApplyPageScale();
 		}
 

--- a/WordsLive/Documents/XpsPresentation.cs
+++ b/WordsLive/Documents/XpsPresentation.cs
@@ -25,7 +25,7 @@ namespace WordsLive.Documents
 {
 	public class XpsPresentation : WpfPresentation<DocumentViewer>, IDocumentPresentation
 	{
-		private DocumentPageScale pageScale = DocumentPageScale.FitToWidth;
+		private DocumentPageScale pageScale = default;
 
 		public XpsPresentation()
 		{
@@ -39,7 +39,7 @@ namespace WordsLive.Documents
 		public void SetSourceDocument(XpsDocument doc)
 		{
 			this.Control.Document = doc.Document.GetFixedDocumentSequence();
-			this.Control.FitToWidth();
+			ApplyPageScale();
 		}
 
 		public void Load()

--- a/WordsLive/Documents/XpsPresentation.cs
+++ b/WordsLive/Documents/XpsPresentation.cs
@@ -32,12 +32,13 @@ namespace WordsLive.Documents
 		private FixedDocument document;
 		private DocumentViewer currentViewer;
 		private int currentPageNumber = 1;
-		private int crossfadeDuration = 500;
+		private int crossfadeDuration;
 
 		public XpsPresentation()
 		{
 			this.Control.Background = Brushes.Black;
 			this.Control.SizeChanged += (sender, args) => ApplyPageScale();
+			this.crossfadeDuration = Properties.Settings.Default.DocumentPageTransition;
 		}
 
 		public void SetSourceDocument(XpsDocument doc)

--- a/WordsLive/Properties/Settings.Designer.cs
+++ b/WordsLive/Properties/Settings.Designer.cs
@@ -720,5 +720,17 @@ namespace WordsLive.Properties {
                 this["SlideshowAutoAdvanceSeconds"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("350")]
+        public int DocumentPageTransition {
+            get {
+                return ((int)(this["DocumentPageTransition"]));
+            }
+            set {
+                this["DocumentPageTransition"] = value;
+            }
+        }
     }
 }

--- a/WordsLive/Properties/Settings.Designer.cs
+++ b/WordsLive/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WordsLive.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -332,21 +332,6 @@ namespace WordsLive.Properties {
             }
             set {
                 this["PresentationTransition"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <s" +
-            "tring>1,True,0,0,0,0</string>\r\n  <string>0,False,0,0,800,600</string>\r\n</ArrayOf" +
-            "String>")]
-        public global::System.Collections.Specialized.StringCollection PresentationAreas {
-            get {
-                return ((global::System.Collections.Specialized.StringCollection)(this["PresentationAreas"]));
-            }
-            set {
-                this["PresentationAreas"] = value;
             }
         }
         
@@ -730,6 +715,21 @@ namespace WordsLive.Properties {
             }
             set {
                 this["DocumentPageTransition"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <s" +
+            "tring>1,True,0,0,0,0</string>\r\n  <string>0,False,0,0,800,600</string>\r\n</ArrayOf" +
+            "String>")]
+        public global::System.Collections.Specialized.StringCollection PresentationAreas {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["PresentationAreas"]));
+            }
+            set {
+                this["PresentationAreas"] = value;
             }
         }
     }

--- a/WordsLive/Properties/Settings.settings
+++ b/WordsLive/Properties/Settings.settings
@@ -82,7 +82,7 @@
     </Setting>
     <Setting Name="PresentationAreas" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
   &lt;string&gt;1,True,0,0,0,0&lt;/string&gt;
   &lt;string&gt;0,False,0,0,800,600&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
@@ -179,6 +179,9 @@
     </Setting>
     <Setting Name="SlideshowAutoAdvanceSeconds" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">10</Value>
+    </Setting>
+    <Setting Name="DocumentPageTransition" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">350</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/WordsLive/Properties/Settings.settings
+++ b/WordsLive/Properties/Settings.settings
@@ -80,13 +80,6 @@
     <Setting Name="PresentationTransition" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">500</Value>
     </Setting>
-    <Setting Name="PresentationAreas" Type="System.Collections.Specialized.StringCollection" Scope="User">
-      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
-  &lt;string&gt;1,True,0,0,0,0&lt;/string&gt;
-  &lt;string&gt;0,False,0,0,800,600&lt;/string&gt;
-&lt;/ArrayOfString&gt;</Value>
-    </Setting>
     <Setting Name="SongTemplateFile" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
@@ -182,6 +175,13 @@
     </Setting>
     <Setting Name="DocumentPageTransition" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">350</Value>
+    </Setting>
+    <Setting Name="PresentationAreas" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;string&gt;1,True,0,0,0,0&lt;/string&gt;
+  &lt;string&gt;0,False,0,0,800,600&lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/WordsLive/Properties/Settings.settings
+++ b/WordsLive/Properties/Settings.settings
@@ -82,7 +82,7 @@
     </Setting>
     <Setting Name="PresentationAreas" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
   &lt;string&gt;1,True,0,0,0,0&lt;/string&gt;
   &lt;string&gt;0,False,0,0,800,600&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>

--- a/WordsLive/Resources/Resource.Designer.cs
+++ b/WordsLive/Resources/Resource.Designer.cs
@@ -1501,6 +1501,15 @@ namespace WordsLive.Resources {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Transition between PDF/XPS pages: ähnelt.
+        /// </summary>
+        public static string seLabelTransitionDocumentPages {
+            get {
+                return ResourceManager.GetString("seLabelTransitionDocumentPages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Transition between images: ähnelt.
         /// </summary>
         public static string seLabelTransitionImages {

--- a/WordsLive/Resources/Resource.de.resx
+++ b/WordsLive/Resources/Resource.de.resx
@@ -1011,4 +1011,7 @@
   <data name="dttPreviewLabel" xml:space="preserve">
     <value>Vorschau</value>
   </data>
+  <data name="seLabelTransitionDocumentPages" xml:space="preserve">
+    <value>Übergang zwischen PDF/XPS-Seiten:</value>
+  </data>
 </root>

--- a/WordsLive/Resources/Resource.resx
+++ b/WordsLive/Resources/Resource.resx
@@ -1011,4 +1011,7 @@
   <data name="dttPreviewLabel" xml:space="preserve">
     <value>Preview</value>
   </data>
+  <data name="seLabelTransitionDocumentPages" xml:space="preserve">
+    <value>Transition between PDF/XPS pages:</value>
+  </data>
 </root>

--- a/WordsLive/Resources/pdf.html
+++ b/WordsLive/Resources/pdf.html
@@ -62,10 +62,14 @@
 		}
 
 		var doc;
+		var skipRenderingOnInit = true;
 		var currentPage = 1;
 		var isWholePage = false;
 
 		function renderCurrentPage() {
+			if (skipRenderingOnInit) {
+			    return;
+			}
 			var viewer = document.getElementById('viewer');
 			$(viewer).empty();
 			renderPage(viewer, doc, currentPage, isWholePage);
@@ -78,6 +82,7 @@
 		    PDFJS.getDocument(await bridge.getDocument()).then(async function getPdfForm(pdf) {
 			    doc = pdf;
 				await bridge.onCallbackLoaded();
+				skipRenderingOnInit = false;
 				renderCurrentPage();
 			});
 		})();

--- a/WordsLive/Resources/pdf.html
+++ b/WordsLive/Resources/pdf.html
@@ -117,7 +117,7 @@
 		var skipRenderingOnInit = true;
 		var currentPage = 1;
 		var isWholePage = false;
-		var crossfadeDuration = 500;
+		var crossfadeDuration = 0;
 
 		function renderCurrentPage(useTransition = false) {
 			if (skipRenderingOnInit) {
@@ -134,8 +134,11 @@
 
 		(async function () {
 		    await CefSharp.BindObjectAsync("bridge");
-		
-			// Fetch the PDF document from the URL using promices
+
+		    isWholePage = await bridge.getRenderWholePage();
+		    crossfadeDuration = await bridge.getTransitionDuration();
+
+		    // Fetch the PDF document from the URL using promises
 		    PDFJS.getDocument(await bridge.getDocument()).then(async function getPdfForm(pdf) {
 			    doc = pdf;
 				await bridge.onCallbackLoaded();

--- a/WordsLive/Resources/pdf.html
+++ b/WordsLive/Resources/pdf.html
@@ -9,27 +9,24 @@
   
 	<style>
 		body { margin: 0; overflow: hidden; background-color: black;}
-		.pdfpage { position:relative; top: 0; left: 0; border-bottom: 1px solid gray; margin: auto; }
-		.pdfpage > canvas { position: absolute; top: 0; left: 0; }
-		.pdfpage > div { position: absolute; top: 0; left: 0; }
+		#viewer { display: flex; justify-content: center; align-items: center; height: 100vh; }
+		.pdfpage { margin: auto; }
 	</style>
 
 	<script type="text/javascript">
 		'use strict';
 
-		var doc;
-		var isWholePage = false;
-		var unscaledViewport = null;
-		var scale;
-
-		function renderPage(div, pdf, pageNumber, callback) {
+		function renderPage(div, pdf, pageNumber, wholePage) {
 			pdf.getPage(pageNumber).then(function(page) {
-				if (unscaledViewport === null) {
-					unscaledViewport = page.getViewport(1);
+				var unscaledViewport = page.getViewport(1);
+				var scale;
+				if (wholePage) {
+					scale = Math.min(
+						$(document).width() / unscaledViewport.width,
+						$(document).height() / unscaledViewport.height
+					);
+				} else {
 					scale = $(document).width() / unscaledViewport.width;
-					if (isWholePage && unscaledViewport.height * scale > $(document).height()) {
-						scale = $(document).height() / unscaledViewport.height;
-					}
 				}
 				var viewport = page.getViewport(scale);
 
@@ -56,7 +53,7 @@
 					canvasContext: context,
 					viewport: viewport
 				};
-				page.render(renderContext).then(callback);
+				page.render(renderContext);
 
 				// Prepare and populate form elements layer
 				var formDiv = document.createElement('div');
@@ -65,19 +62,13 @@
 		}
 
 		var doc;
+		var currentPage = 1;
+		var isWholePage = false;
 
-		function renderAll() {
-			unscaledViewport = null;
-			// Rendering all pages starting from first
+		function renderCurrentPage() {
 			var viewer = document.getElementById('viewer');
 			$(viewer).empty();
-			var pageNumber = 1;
-			renderPage(viewer, doc, pageNumber++, function pageRenderingComplete() {
-				if (pageNumber > doc.numPages)
-					return; // All pages rendered
-				// Continue rendering of the next page
-				renderPage(viewer, doc, pageNumber++, pageRenderingComplete);
-			});
+			renderPage(viewer, doc, currentPage, isWholePage);
 		}
 
 		(async function () {
@@ -87,12 +78,12 @@
 		    PDFJS.getDocument(await bridge.getDocument()).then(async function getPdfForm(pdf) {
 			    doc = pdf;
 				await bridge.onCallbackLoaded();
-				renderAll();
+				renderCurrentPage();
 			});
 		})();
 
 		$(window).resize(function () {
-			renderAll();
+			renderCurrentPage();
 		});
 
 		$(function () {
@@ -105,34 +96,28 @@
 		function wholePage() {
 			if (!isWholePage) {
 				isWholePage = true;
-				renderAll();
+				renderCurrentPage();
 			}
 		}
 
 		function fitToWidth() {
 			if (isWholePage) {
 				isWholePage = false;
-				renderAll();
+				renderCurrentPage();
 			}
 		}
 
 		function gotoPage(p) {
-			if (p >= 1 && p <= doc.numPages) {
-				$(window).scrollTop($('#page_'+p).offset().top)
+			p = Math.max(1, Math.min(p, getPageCount()));
+			if (currentPage === p) {
+				return;
 			}
+			currentPage = p;
+			renderCurrentPage();
 		}
 	  
 		function getCurrentPage() {
-			var t = $(window).scrollTop();
-			if (t == 0)
-				return 1;
-			
-			for (var p = 1; p <= doc.numPages; p++) {
-				//alert(p +': '+$('#page_' + p).offset().top + ' >= ' + t);
-				if ($('#page_'+p).offset().top >= t)
-					return p;
-			}
-			return doc.numPages;
+			return currentPage;
 		}
 		
 		function getPageCount() {

--- a/WordsLive/Resources/pdf.html
+++ b/WordsLive/Resources/pdf.html
@@ -8,22 +8,66 @@
 	<script type="text/javascript" src="asset://WordsLive.Core/thirdparty/jquery.mousewheel.js"></script>
   
 	<style>
-		body { margin: 0; overflow: hidden; background-color: black;}
-		#viewer { display: flex; justify-content: center; align-items: center; height: 100vh; }
-		.pdfpage { margin: auto; }
+		body {
+			margin: 0;
+			overflow: hidden;
+			background-color: black;
+		}
+
+		#viewer {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100vw;
+			height: 100vh;
+		}
+
+		/*
+			* Within the #viewer div, the JS code below will create the dynamic elements.
+			* One page is within a ".pdfpageoverlay > .pdfpageviewport > .pdfpage" construction.
+			* Typically we only have one page displayed, but when transitioning from one page to the next
+			  we keep the old elements while the new page is being rendered (and then switch to it
+			  with a crossfade transition).
+			* The ".pdfpageoverlay" div is used for stacking pages on top of each other, without them
+			  affecting each other, by using CSS absolute positioning.
+			* The ".pdfpageviewport" and ".pdfpage" styles ensure horizontal and vertical positioning of
+			  the page (for both scaling options, i.e., fit-to-width and whole-page).
+		*/
+
+		.pdfpageoverlay {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100vw;
+			height: 100vh;
+			background-color: black;
+		}
+
+		.pdfpageviewport {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			position: relative;
+			width: 100vw;
+			height: 100vh;
+		}
+
+		.pdfpage {
+			margin: auto;
+		}
 	</style>
 
 	<script type="text/javascript">
 		'use strict';
 
-		function renderPage(div, pdf, pageNumber, wholePage) {
+		function renderPage(div, pdf, pageNumber, wholePage, callback) {
 			pdf.getPage(pageNumber).then(function(page) {
 				var unscaledViewport = page.getViewport(1);
 				var scale;
 				if (wholePage) {
 					scale = Math.min(
-						$(document).width() / unscaledViewport.width,
-						$(document).height() / unscaledViewport.height
+						$(window).width() / unscaledViewport.width,
+						$(window).height() / unscaledViewport.height
 					);
 				} else {
 					scale = $(document).width() / unscaledViewport.width;
@@ -33,19 +77,25 @@
 				var pageDisplayWidth = viewport.width;
 				var pageDisplayHeight = viewport.height;
 
-				var pageDivHolder = document.createElement('div');
-				pageDivHolder.className = 'pdfpage';
-				$(pageDivHolder).attr('id', 'page_'+pageNumber);
-				pageDivHolder.style.width = pageDisplayWidth + 'px';
-				pageDivHolder.style.height = pageDisplayHeight + 'px';
-				div.appendChild(pageDivHolder);
+				var pageOverlayDiv = document.createElement('div');
+				pageOverlayDiv.className = 'pdfpageoverlay';
+				$(pageOverlayDiv).css('display', 'none');
+				var pageViewportDiv = document.createElement('div');
+				pageViewportDiv.className = 'pdfpageviewport';
+				var pageDiv = document.createElement('div');
+				pageDiv.className = 'pdfpage';
+				pageDiv.style.width = pageDisplayWidth + 'px';
+				pageDiv.style.height = pageDisplayHeight + 'px';
+				div.appendChild(pageOverlayDiv);
+				pageOverlayDiv.appendChild(pageViewportDiv);
+				pageViewportDiv.appendChild(pageDiv);
 
 				// Prepare canvas using PDF page dimensions
 				var canvas = document.createElement('canvas');
 				var context = canvas.getContext('2d');
 				canvas.width = pageDisplayWidth;
 				canvas.height = pageDisplayHeight;
-				pageDivHolder.appendChild(canvas);
+				pageDiv.appendChild(canvas);
 
 
 				// Render PDF page into canvas context
@@ -53,11 +103,13 @@
 					canvasContext: context,
 					viewport: viewport
 				};
-				page.render(renderContext);
+				page.render(renderContext).then(function () {
+					callback(pageOverlayDiv);
+				});
 
 				// Prepare and populate form elements layer
 				var formDiv = document.createElement('div');
-				pageDivHolder.appendChild(formDiv);
+				pageDiv.appendChild(formDiv);
 			});
 		}
 
@@ -65,14 +117,19 @@
 		var skipRenderingOnInit = true;
 		var currentPage = 1;
 		var isWholePage = false;
+		var crossfadeDuration = 500;
 
-		function renderCurrentPage() {
+		function renderCurrentPage(useTransition = false) {
 			if (skipRenderingOnInit) {
 			    return;
 			}
 			var viewer = document.getElementById('viewer');
-			$(viewer).empty();
-			renderPage(viewer, doc, currentPage, isWholePage);
+			var oldPageOverlays = $(viewer).children('.pdfpageoverlay');
+			renderPage(viewer, doc, currentPage, isWholePage, function (pageOverlayDiv) {
+			    $(pageOverlayDiv).fadeIn(useTransition ? crossfadeDuration : 0, 'swing', function () {
+			        oldPageOverlays.remove();
+			    });
+			});
 		}
 
 		(async function () {
@@ -118,7 +175,7 @@
 				return;
 			}
 			currentPage = p;
-			renderCurrentPage();
+			renderCurrentPage(true);
 		}
 	  
 		function getCurrentPage() {

--- a/WordsLive/SettingsWindow.xaml
+++ b/WordsLive/SettingsWindow.xaml
@@ -36,6 +36,7 @@
 						<RowDefinition Height="Auto"/>
 						<RowDefinition Height="Auto"/>
 						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
 					</Grid.RowDefinitions>
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto"/>
@@ -69,6 +70,9 @@
 					<Label Grid.Row="3" Content="{x:Static resx:Resource.seLabelTransitionImages}" HorizontalAlignment="Left" Margin="0" VerticalAlignment="Top" />
 					<TextBox Grid.Row="3" Grid.Column="1" Height="23" Margin="0" Style="{StaticResource textBoxInError}" Text="{Binding ImageTransition, Mode=TwoWay, ValidatesOnDataErrors=True}" TextAlignment="Right" VerticalAlignment="Top" />
 					<TextBlock Grid.Row="3" Grid.Column="2" Height="23" Margin="3,0,0,0" Text="ms" VerticalAlignment="Center" />
+					<Label Grid.Row="4" Content="{x:Static resx:Resource.seLabelTransitionDocumentPages}" HorizontalAlignment="Left" Margin="0" VerticalAlignment="Top" />
+					<TextBox Grid.Row="4" Grid.Column="1" Height="23" Margin="0" Style="{StaticResource textBoxInError}" Text="{Binding DocumentPageTransition, Mode=TwoWay, ValidatesOnDataErrors=True}" TextAlignment="Right" VerticalAlignment="Top" />
+					<TextBlock Grid.Row="4" Grid.Column="2" Height="23" Margin="3,0,0,0" Text="ms" VerticalAlignment="Center" />
 				</Grid>
 			</TabItem>
 			<TabItem Header="{x:Static resx:Resource.seTabTemplate}">

--- a/WordsLive/SettingsWindow.xaml.cs
+++ b/WordsLive/SettingsWindow.xaml.cs
@@ -111,6 +111,18 @@ namespace WordsLive
 			}
 		}
 
+		public int DocumentPageTransition
+		{
+			get
+			{
+				return Properties.Settings.Default.DocumentPageTransition;
+			}
+			set
+			{
+				Properties.Settings.Default.DocumentPageTransition = value;
+			}
+		}
+
 		public string SongTemplateFile
 		{
 			get

--- a/WordsLive/app.config
+++ b/WordsLive/app.config
@@ -90,7 +90,7 @@
       </setting>
       <setting name="PresentationAreas" serializeAs="Xml">
         <value>
-          <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <string>1,True,0,0,0,0</string>
             <string>0,False,0,0,800,600</string>
           </ArrayOfString>
@@ -185,6 +185,9 @@
       </setting>
       <setting name="SlideshowAutoAdvanceSeconds" serializeAs="String">
         <value>10</value>
+      </setting>
+      <setting name="DocumentPageTransition" serializeAs="String">
+        <value>350</value>
       </setting>
     </WordsLive.Properties.Settings>
   </userSettings>

--- a/WordsLive/app.config
+++ b/WordsLive/app.config
@@ -90,7 +90,7 @@
       </setting>
       <setting name="PresentationAreas" serializeAs="Xml">
         <value>
-          <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <string>1,True,0,0,0,0</string>
             <string>0,False,0,0,800,600</string>
           </ArrayOfString>

--- a/WordsLive/app.config
+++ b/WordsLive/app.config
@@ -62,10 +62,10 @@
         <value>False</value>
       </setting>
       <setting name="SongsDirectory" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="BackgroundsDirectory" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="ChooseBackgroundWindowTop" serializeAs="String">
         <value>0</value>
@@ -88,16 +88,8 @@
       <setting name="PresentationTransition" serializeAs="String">
         <value>500</value>
       </setting>
-      <setting name="PresentationAreas" serializeAs="Xml">
-        <value>
-          <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-            <string>1,True,0,0,0,0</string>
-            <string>0,False,0,0,800,600</string>
-          </ArrayOfString>
-        </value>
-      </setting>
       <setting name="SongTemplateFile" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="SongSlideTransition" serializeAs="String">
         <value>350</value>
@@ -160,19 +152,19 @@
         <value>True</value>
       </setting>
       <setting name="ApplicationVersion" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="NoUpdateVersion" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="LastPortfolioDirectory" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="LastMediaDirectory" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="LastSongDirectory" serializeAs="String">
-        <value/>
+        <value />
       </setting>
       <setting name="EditorShowOrderSlidesContent" serializeAs="String">
         <value>True</value>
@@ -188,6 +180,14 @@
       </setting>
       <setting name="DocumentPageTransition" serializeAs="String">
         <value>350</value>
+      </setting>
+      <setting name="PresentationAreas" serializeAs="Xml">
+        <value>
+          <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <string>1,True,0,0,0,0</string>
+            <string>0,False,0,0,800,600</string>
+          </ArrayOfString>
+        </value>
       </setting>
     </WordsLive.Properties.Settings>
   </userSettings>


### PR DESCRIPTION
There are several issues with the old approach to PDF/XPS document rendering, where the whole document is rendered immediately and we just scroll to the desired position:
* Depending on page dimensions, screen dimensions and scaling options a part of the next page can be visible (see #14)
* When more than one page is visible on the screen, then determining the current page (from the scrolling position) can be problematic.
* When pages do not all have the same dimensions, then individually it seems like the "whole page" or "fit to width" scaling does not work.

Changes in this PR:
* Change the mechanism to only render one page of the document instead of all pages, for both PDF and XPS. Make navigation to pages explicit by rendering exactly the requested page.
* Having the old page and new page in parallel is necessary for an instant switch to the new page. This makes it simple to have a transition (crossfade). The transition time is configurable in global settings, has a default of 350 ms, but can be zero.
* The default page scaling is now "whole page" because that is imho desired in almost all cases (at least for all types of presentation documents in landscape orientation, which is what we normally have).
* The page scaling option per document is now saved within the portfolio.
