### PR TITLE
Support subfolders in local song storage

### DIFF
--- a/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
+++ b/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
@@ -128,6 +128,29 @@ namespace WordsLive.Core.Songs.Storage
 			return File.Exists(Path.Combine(directory, name));
 		}
 
+		public override bool IsValidName(string name)
+		{
+			if (string.IsNullOrEmpty(name) || name.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+				return false;
+
+			if (Path.IsPathRooted(name))
+				return false;
+
+			var fileName = Path.GetFileName(name);
+			if (string.IsNullOrEmpty(fileName) || fileName.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+				return false;
+
+			var subdirectoryName = Path.GetDirectoryName(name);
+			if (!Directory.Exists(Path.Combine(directory, subdirectoryName)))
+				return false;
+
+			var fullPath = Path.GetFullPath(Path.Combine(directory, name));
+			if (!fullPath.StartsWith(directory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+				return false;
+
+			return true;
+		}
+
 		public override Uri TryRewriteUri(Uri uri)
 		{
 			if (uri.IsFile)

--- a/WordsLive.Core/Songs/Storage/SongData.cs
+++ b/WordsLive.Core/Songs/Storage/SongData.cs
@@ -17,7 +17,6 @@
  */
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -124,7 +123,7 @@ namespace WordsLive.Core.Songs.Storage
 			return new SongData
 			{
 				Title = song.Title,
-				Filename = Path.GetFileName(Uri.UnescapeDataString(song.Uri.Segments.Last())),
+				Filename = Uri.UnescapeDataString(String.Join("/", song.Uri.Segments.Skip(1))),
 				Text = song.TextWithoutChords,
 				Copyright = String.Join(" ", song.Copyright.Split('\n').Select(line => line.Trim())),
 				Sources = String.Join("; ", song.Sources),

--- a/WordsLive.Core/Songs/Storage/SongStorage.cs
+++ b/WordsLive.Core/Songs/Storage/SongStorage.cs
@@ -112,6 +112,14 @@ namespace WordsLive.Core.Songs.Storage
 
 		public abstract bool Exists(string name);
 
+		/// <summary>
+		/// Check if the given name of the song is allowed (independent of whether it already exists
+		/// or not; checks the general format and checks especially for invalid characters).
+		/// </summary>
+		/// <param name="name">The name of the song.</param>
+		/// <returns>True if the song name can be used for saving a song.</returns>
+		public abstract bool IsValidName(string name);
+
 		//public Song Read(string name, ISongReader reader)
 		//{
 		//	throw new NotImplementedException();

--- a/WordsLive/Editor/SaveFilenameDialog.xaml.cs
+++ b/WordsLive/Editor/SaveFilenameDialog.xaml.cs
@@ -17,7 +17,6 @@
  */
 
 using System.ComponentModel;
-using System.IO;
 using System.Windows;
 using WordsLive.Core;
 using WordsLive.Resources;
@@ -103,7 +102,7 @@ namespace WordsLive.Editor
 				switch (name)
 				{
 					case "FilenameWithoutExtension":
-						if (string.IsNullOrEmpty(this.filename) || this.filename.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
+						if (!DataManager.Songs.IsValidName(this.filename))
 							return Resource.sfInvalidFilename;
 
 						break;


### PR DESCRIPTION
In our setup, we do not have all songs in the same folder, but we also have subfolders. So far we need to drag&drop song files from subfolders into the portfolio and can't use the song list (or search for them via the song list).

This is a proposal to allow subfolders in the local song storage. It changes the song list to work recursively and also allows to use e.g. "Existing Folder/Song name" when saving a new song. Otherwise this PR does not really advertise the subfolder possibility, existing subfolders can be used, but there is no special support for them in the UI.

I am not sure why so far no subfolders are allowed, so there could be reasons that I don't know about.