### PR TITLE
Avoid exception when duration for a video is unknown

### DIFF
--- a/WordsLive/AudioVideo/WpfWrapper.xaml.cs
+++ b/WordsLive/AudioVideo/WpfWrapper.xaml.cs
@@ -40,7 +40,7 @@ namespace WordsLive.AudioVideo
 
 		public override TimeSpan Duration
 		{
-			get { return player.NaturalDuration.TimeSpan; }
+			get { return player.NaturalDuration.HasTimeSpan ? player.NaturalDuration.TimeSpan : TimeSpan.Zero; }
 		}
 
 		public override int Position


### PR DESCRIPTION
For one video file I encountered a "System.InvalidOperationException" when trying to use it in WordsLive. Exact message:
```
Es kann kein TimeSpan-Eigenschaftswert für den Duration-Wert "Automatic" zurückgegeben werden. Prüfen Sie vor dem Anfordern des TimeSpan-Eigenschaftswerts von "Duration" die HasTimeSpan-Eigenschaft.
```

This change now just uses zero as a fallback if the length is unknown. Playing the video still works, just the slider cannot be used.
(With the VLC integration the same file worked. The problem is only there when VLC is disabled / no 32-bit VLC is installed.)