### PR TITLE
Upgrade CefSharp packages to v139

### DIFF
--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -179,12 +179,6 @@
 				<File Source="$(var.WordsLive.TargetDir)libGLESv2.dll" Name="libGLESv2.dll" KeyPath="yes" />
 			</Component>
 			<Component>
-				<File Source="$(var.WordsLive.TargetDir)README.txt" Name="README.txt" KeyPath="yes" />
-			</Component>
-			<Component>
-				<File Source="$(var.WordsLive.TargetDir)snapshot_blob.bin" Name="snapshot_blob.bin" KeyPath="yes" />
-			</Component>
-			<Component>
 				<File Source="$(var.WordsLive.TargetDir)v8_context_snapshot.bin" Name="v8_context_snapshot.bin" KeyPath="yes" />
 			</Component>
 			<Component>

--- a/WordsLive/Cef/CefRequestHandler.cs
+++ b/WordsLive/Cef/CefRequestHandler.cs
@@ -71,7 +71,7 @@ namespace WordsLive.Cef
 			return true;
 		}
 
-		public void OnRenderProcessTerminated(IWebBrowser chromiumWebBrowser, IBrowser browser, CefTerminationStatus status)
+		public void OnRenderProcessTerminated(IWebBrowser chromiumWebBrowser, IBrowser browser, CefTerminationStatus status, int errorCode, string errorMessage)
 		{
 			RenderProcessTerminated?.Invoke(chromiumWebBrowser, new RenderProcessTerminatedEventArgs {
 				ChromiumWebBrowser = chromiumWebBrowser,

--- a/WordsLive/Cef/CefWrapper.xaml.cs
+++ b/WordsLive/Cef/CefWrapper.xaml.cs
@@ -62,7 +62,7 @@ namespace WordsLive.Cef
 			}
 			else
 			{
-				offscreenControl = new CefSharp.OffScreen.ChromiumWebBrowser("", new BrowserSettings { BackgroundColor = CefSharp.Cef.ColorSetARGB(0, 0, 0, 0) } );
+				offscreenControl = new CefSharp.OffScreen.ChromiumWebBrowser("about:blank", new BrowserSettings { BackgroundColor = CefSharp.Cef.ColorSetARGB(0, 0, 0, 0) } );
 				offscreenControl.Size = this.area.WindowSize;
 				area.WindowSizeChanged += area_WindowSizeChanged;
 			}

--- a/WordsLive/WordsLive.csproj
+++ b/WordsLive/WordsLive.csproj
@@ -576,10 +576,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CefSharp.OffScreen">
-      <Version>116.0.230</Version>
+      <Version>139.0.280</Version>
     </PackageReference>
     <PackageReference Include="CefSharp.Wpf">
-      <Version>116.0.230</Version>
+      <Version>139.0.280</Version>
     </PackageReference>
     <PackageReference Include="DotNetZip">
       <Version>1.16.0</Version>


### PR DESCRIPTION
The upgrade of CefSharp (where VS shows known vulnerabilities for the old version) is mostly straightforward. Two files do not exist anymore (only relevant for the installer). The songs rendering failed at first because no URL is given to the chromium process, but adding "about:blank" fixed this.

I built the installer once and tested the installation on another system. It worked fine (checked viewing songs and PDF files).