### PR TITLE
Fix possible null exception in song presentation resize handler

### DIFF
--- a/WordsLive.Core/Resources/SongPresentation.js
+++ b/WordsLive.Core/Resources/SongPresentation.js
@@ -79,6 +79,8 @@ function SongPresentation(id, song, featureLevel) {
 	var ths = this;
 
 	$(window).bind('resize.presentation_' + this.id, function () {
+		if (ths.slide === null)
+			return;
 		ths.container.find('.song-main > div > div > div').css('font-size', (ths.slide.Size * SongPresentation.FontFactor * ths.getFactor()) + "pt");
 		ths.updateStyle();
 	});


### PR DESCRIPTION
On our presentation computer, we now get an exception when switching to another song:
```
SongDisplayController encountered JS error in asset://wordslive.core/SongPresentation.js (line 82): Uncaught TypeError: Cannot read properties of null (reading 'Size')
```
(this is in the window resize handler when accessing the `slide` variable)

This was not always the case, our guess is that it appeared with the Windows 11 upgrade.

On my local system I can't reproduce it. It seems to be a race condition, so my approach is to simply do nothing if the slide variable is not populated yet. I will test next Sunday if that helps, so keeping this as a draft PR for now.