### PR TITLE
Fix escaping of file names for song URIs

### DIFF
--- a/WordsLive.Core.Tests/Songs/SongUriTests.cs
+++ b/WordsLive.Core.Tests/Songs/SongUriTests.cs
@@ -53,7 +53,7 @@ namespace WordsLive.Core.Tests.Songs
 			{
 				return;
 			}
-			Assert.Equal(filename.Replace("\\", "/"), SongUri.GetFilename(new Uri(uri)));
+			Assert.Equal(filename, SongUri.GetFilename(new Uri(uri)));
 		}
 	}
 }

--- a/WordsLive.Core.Tests/Songs/SongUriTests.cs
+++ b/WordsLive.Core.Tests/Songs/SongUriTests.cs
@@ -28,11 +28,11 @@ namespace WordsLive.Core.Tests.Songs
 			new TheoryData<string, string, bool>
 			{
 				{ "test.ppl", "song:///test.ppl", false },
-				{ "test and test.ppl", "song:///test and test.ppl", false },
 				{ "test+test.ppl", "song:///test%2Btest.ppl", false },
 				{ "test&test.ppl", "song:///test%26test.ppl", false },
-				{ "test (test).ppl", "song:///test %28test%29.ppl", false },
-				{ "test [test].ppl", "song:///test %5Btest%5D.ppl", false },
+				{ "test (test).ppl", "song:///test%20%28test%29.ppl", false },
+				{ "test [test].ppl", "song:///test%20%5Btest%5D.ppl", false },
+				{ "test äöüß.ppl", "song:///test%20%C3%A4%C3%B6%C3%BC%C3%9F.ppl", false },
 				{ "#test.ppl", "song:///%23test.ppl", false },
 				{ "subfolder/test.ppl", "song:///subfolder/test.ppl", false },
 				{ "subfolder\\test.ppl", "song:///subfolder/test.ppl", true },
@@ -42,7 +42,7 @@ namespace WordsLive.Core.Tests.Songs
 		[MemberData(nameof(TestData))]
 		public void GetUri(string filename, string uri, bool _)
 		{
-			Assert.Equal(uri, SongUri.GetUri(filename).ToString());
+			Assert.Equal(uri, SongUri.GetUri(filename).OriginalString);
 		}
 
 		[Theory]

--- a/WordsLive.Core.Tests/Songs/SongUriTests.cs
+++ b/WordsLive.Core.Tests/Songs/SongUriTests.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * WordsLive - worship projection software
+ * Copyright (c) 2014 Patrick Reisert
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using WordsLive.Core.Songs.Storage;
+using Xunit;
+
+namespace WordsLive.Core.Tests.Songs
+{
+	public class SongUriTests
+	{
+		public static TheoryData<string, string, bool> TestData =>
+			new TheoryData<string, string, bool>
+			{
+				{ "test.ppl", "song:///test.ppl", false },
+				{ "test and test.ppl", "song:///test and test.ppl", false },
+				{ "test+test.ppl", "song:///test%2Btest.ppl", false },
+				{ "test&test.ppl", "song:///test%26test.ppl", false },
+				{ "test (test).ppl", "song:///test %28test%29.ppl", false },
+				{ "test [test].ppl", "song:///test %5Btest%5D.ppl", false },
+				{ "#test.ppl", "song:///%23test.ppl", false },
+				{ "subfolder/test.ppl", "song:///subfolder/test.ppl", false },
+				{ "subfolder\\test.ppl", "song:///subfolder/test.ppl", true },
+			};
+
+		[Theory]
+		[MemberData(nameof(TestData))]
+		public void GetUri(string filename, string uri, bool _)
+		{
+			Assert.Equal(uri, SongUri.GetUri(filename).ToString());
+		}
+
+		[Theory]
+		[MemberData(nameof(TestData))]
+		public void GetFilename(string filename, string uri, bool oneWayOnly)
+		{
+			if (oneWayOnly)
+			{
+				return;
+			}
+			Assert.Equal(filename.Replace("\\", "/"), SongUri.GetFilename(new Uri(uri)));
+		}
+	}
+}

--- a/WordsLive.Core.Tests/WordsLive.Core.Tests.csproj
+++ b/WordsLive.Core.Tests/WordsLive.Core.Tests.csproj
@@ -51,6 +51,7 @@
     </Compile>
     <Compile Include="DataTests.cs" />
     <Compile Include="ExtensionsTests.cs" />
+    <Compile Include="Songs\SongUriTests.cs" />
     <Compile Include="Songs\ChordTests.cs" />
     <Compile Include="Songs\SongPartTests.cs" />
     <Compile Include="Songs\SongSlideTests.cs" />

--- a/WordsLive.Core/MediaManager.cs
+++ b/WordsLive.Core/MediaManager.cs
@@ -239,7 +239,7 @@ namespace WordsLive.Core
 					{
 						foreach (Media m in from i in root.Element("order").Elements("item")
 											select (i.Attribute("mediatype").Value == "powerpraise-song" && !i.Element("file").Value.Contains('\\')) ?
-											LoadMediaMetadata(new Uri("song:///" + i.Element("file").Value), LoadOptions(i)) :
+											LoadMediaMetadata(new Uri("song:///" + Uri.EscapeDataString(i.Element("file").Value)), LoadOptions(i)) :
 											LoadMediaMetadata(new Uri(i.Element("file").Value), LoadOptions(i)))
 						{
 							yield return m;
@@ -250,7 +250,7 @@ namespace WordsLive.Core
 					else if (root.Attribute("version").Value == "2.2")
 					{
 						foreach (Media m in from i in root.Elements("item")
-													select MediaManager.LoadMediaMetadata(new Uri("song:///" + i.Element("file").Value), null))
+													select MediaManager.LoadMediaMetadata(new Uri("song:///" + Uri.EscapeDataString(i.Element("file").Value)), null))
 						{
 							yield return m;
 						}

--- a/WordsLive.Core/MediaManager.cs
+++ b/WordsLive.Core/MediaManager.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using WordsLive.Core.Songs.Storage;
 
 namespace WordsLive.Core
 {
@@ -239,7 +240,7 @@ namespace WordsLive.Core
 					{
 						foreach (Media m in from i in root.Element("order").Elements("item")
 											select (i.Attribute("mediatype").Value == "powerpraise-song" && !i.Element("file").Value.Contains('\\')) ?
-											LoadMediaMetadata(new Uri("song:///" + Uri.EscapeDataString(i.Element("file").Value)), LoadOptions(i)) :
+											LoadMediaMetadata(SongUri.GetUri(i.Element("file").Value), LoadOptions(i)) :
 											LoadMediaMetadata(new Uri(i.Element("file").Value), LoadOptions(i)))
 						{
 							yield return m;
@@ -250,7 +251,7 @@ namespace WordsLive.Core
 					else if (root.Attribute("version").Value == "2.2")
 					{
 						foreach (Media m in from i in root.Elements("item")
-													select MediaManager.LoadMediaMetadata(new Uri("song:///" + Uri.EscapeDataString(i.Element("file").Value)), null))
+													select MediaManager.LoadMediaMetadata(SongUri.GetUri(i.Element("file").Value), null))
 						{
 							yield return m;
 						}
@@ -336,7 +337,7 @@ namespace WordsLive.Core
 		private static string GetMediaPathFromUri(Uri uri)
 		{
 			if (uri.Scheme == "song")
-				return Uri.UnescapeDataString(uri.AbsolutePath).Substring(1);
+				return SongUri.GetFilename(uri);
 
 			if (uri.IsFile)
 				return uri.LocalPath;

--- a/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
+++ b/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
@@ -62,7 +62,8 @@ namespace WordsLive.Core.Songs.Storage
 					var escapedRelativePath = new Uri(directory + Path.DirectorySeparatorChar)
 						.MakeRelativeUri(new Uri(file))
 						.ToString();
-					var song = new Song(new Uri("song:///" + escapedRelativePath), new SongUriResolver(this));
+					var relativePath = Uri.UnescapeDataString(escapedRelativePath);
+					var song = new Song(SongUri.GetUri(relativePath), new SongUriResolver(this));
 					data = SongData.Create(song);
 				}
 				catch { }
@@ -162,8 +163,7 @@ namespace WordsLive.Core.Songs.Storage
 				if (filePath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
 				{
 					var relativePath = filePath.Substring(rootPath.Length).Replace(Path.DirectorySeparatorChar, '/');
-					var escapedRelativePath = Uri.EscapeDataString(relativePath);
-					return new Uri("song:///" + escapedRelativePath);
+					return SongUri.GetUri(relativePath);
 				}
 			}
 

--- a/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
+++ b/WordsLive.Core/Songs/Storage/LocalSongStorage.cs
@@ -59,10 +59,10 @@ namespace WordsLive.Core.Songs.Storage
 
 				try
 				{
-					var relativePath = new Uri(directory + Path.DirectorySeparatorChar)
+					var escapedRelativePath = new Uri(directory + Path.DirectorySeparatorChar)
 						.MakeRelativeUri(new Uri(file))
 						.ToString();
-					var song = new Song(new Uri("song:///" + relativePath), new SongUriResolver(this));
+					var song = new Song(new Uri("song:///" + escapedRelativePath), new SongUriResolver(this));
 					data = SongData.Create(song);
 				}
 				catch { }
@@ -162,7 +162,8 @@ namespace WordsLive.Core.Songs.Storage
 				if (filePath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
 				{
 					var relativePath = filePath.Substring(rootPath.Length).Replace(Path.DirectorySeparatorChar, '/');
-					return new Uri("song:///" + relativePath);
+					var escapedRelativePath = Uri.EscapeDataString(relativePath);
+					return new Uri("song:///" + escapedRelativePath);
 				}
 			}
 

--- a/WordsLive.Core/Songs/Storage/SongData.cs
+++ b/WordsLive.Core/Songs/Storage/SongData.cs
@@ -128,7 +128,7 @@ namespace WordsLive.Core.Songs.Storage
 		{
 			get
 			{
-				return new Uri("song:///" + Filename);
+				return new Uri("song:///" + Uri.EscapeDataString(Filename));
 			}
 		}
 

--- a/WordsLive.Core/Songs/Storage/SongData.cs
+++ b/WordsLive.Core/Songs/Storage/SongData.cs
@@ -128,7 +128,7 @@ namespace WordsLive.Core.Songs.Storage
 		{
 			get
 			{
-				return new Uri("song:///" + Uri.EscapeDataString(Filename));
+				return SongUri.GetUri(Filename);
 			}
 		}
 
@@ -143,7 +143,7 @@ namespace WordsLive.Core.Songs.Storage
 			return new SongData
 			{
 				Title = song.Title,
-				Filename = Uri.UnescapeDataString(String.Join("", song.Uri.Segments.Skip(1))),
+				Filename = song.Uri.Scheme == "song" ? SongUri.GetFilename(song.Uri) : null,
 				Text = song.TextWithoutChords,
 				Translation = song.TranslationWithoutChords,
 				Copyright = String.Join(" ", song.Copyright.Split('\n').Select(line => line.Trim())),

--- a/WordsLive.Core/Songs/Storage/SongUri.cs
+++ b/WordsLive.Core/Songs/Storage/SongUri.cs
@@ -17,6 +17,7 @@
  */
 
 using System;
+using System.Linq;
 
 namespace WordsLive.Core.Songs.Storage
 {
@@ -32,7 +33,8 @@ namespace WordsLive.Core.Songs.Storage
 		/// <returns>The "song://" URI with encoded special characters if needed.</returns>
 		public static Uri GetUri(string filename)
 		{
-			return new Uri("song:///" + Uri.EscapeDataString(filename));
+			var escapedFilename = string.Join("/", filename.Split('/', '\\').Select(Uri.EscapeDataString));
+			return new Uri("song:///" + escapedFilename);
 		}
 
 		/// <summary>

--- a/WordsLive.Core/Songs/Storage/SongUri.cs
+++ b/WordsLive.Core/Songs/Storage/SongUri.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * WordsLive - worship projection software
+ * Copyright (c) 2013 Patrick Reisert
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+
+namespace WordsLive.Core.Songs.Storage
+{
+	/// <summary>
+	/// Methods for handling "song://" URIs.
+	/// </summary>
+	public class SongUri
+	{
+		/// <summary>
+		/// Returns a "song://" URI for the given filename within the song storage folder.
+		/// </summary>
+		/// <param name="filename">The filename. Include the subfolder when the file is in a subfolder of the song storage folder.</param>
+		/// <returns>The "song://" URI with encoded special characters if needed.</returns>
+		public static Uri GetUri(string filename)
+		{
+			return new Uri("song:///" + Uri.EscapeDataString(filename));
+		}
+
+		/// <summary>
+		/// Extracts the filename within the song storage folder from a "song://" URI.
+		/// </summary>
+		/// <param name="uri">The "song://" URI.</param>
+		/// <returns>The filename relative to the song storage folder. If the file is in a subfolder, then this includes the subfolder and the used delimiter is "/".</returns>
+		public static string GetFilename(Uri uri)
+		{
+			if (uri.Scheme != "song")
+				throw new ArgumentException("uri");
+
+			return Uri.UnescapeDataString(uri.AbsolutePath).Substring(1);
+		}
+	}
+}

--- a/WordsLive.Core/Songs/Storage/SongUriResolver.cs
+++ b/WordsLive.Core/Songs/Storage/SongUriResolver.cs
@@ -61,7 +61,7 @@ namespace WordsLive.Core.Songs.Storage
 		{
 			if (uri.Scheme == "song")
 			{
-				return (ForceStorage ?? DataManager.Songs).Get(GetFilename(uri)).Stream;
+				return (ForceStorage ?? DataManager.Songs).Get(SongUri.GetFilename(uri)).Stream;
 				
 			}
 			else if (uri.IsFile)
@@ -85,7 +85,7 @@ namespace WordsLive.Core.Songs.Storage
 		{
 			if (uri.Scheme == "song")
 			{
-				var entry = await (ForceStorage ?? DataManager.Songs).GetAsync(GetFilename(uri), cancellation);
+				var entry = await (ForceStorage ?? DataManager.Songs).GetAsync(SongUri.GetFilename(uri), cancellation);
 				return entry.Stream;
 			}
 			else if (uri.IsFile)
@@ -109,7 +109,7 @@ namespace WordsLive.Core.Songs.Storage
 		{
 			if (uri.Scheme == "song")
 			{
-				return (ForceStorage ?? DataManager.Songs).Put(GetFilename(uri));
+				return (ForceStorage ?? DataManager.Songs).Put(SongUri.GetFilename(uri));
 			}
 			else if (uri.IsFile)
 			{
@@ -119,14 +119,6 @@ namespace WordsLive.Core.Songs.Storage
 			{
 				throw new NotSupportedException();
 			}
-		}
-
-		private static string GetFilename(Uri uri)
-		{
-			if (uri.Scheme != "song")
-				throw new ArgumentException("uri");
-
-			return Uri.UnescapeDataString(uri.AbsolutePath).Substring(1);
 		}
 	}
 }

--- a/WordsLive.Core/WordsLive.Core.csproj
+++ b/WordsLive.Core/WordsLive.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Songs\ISongElementWithSize.cs" />
     <Compile Include="Songs\SongMedia.cs" />
     <Compile Include="Songs\Storage\SongStorageEntry.cs" />
+    <Compile Include="Songs\Storage\SongUri.cs" />
     <Compile Include="Songs\Storage\SongUriResolver.cs" />
     <Compile Include="Songs\Storage\BackgroundStorage.cs" />
     <Compile Include="Songs\Storage\BackgroundStorageEntry.cs" />

--- a/WordsLive/Editor/EditorWindow.xaml.cs
+++ b/WordsLive/Editor/EditorWindow.xaml.cs
@@ -212,7 +212,7 @@ namespace WordsLive.Editor
 
 			if (dlg.ShowDialog() == true)
 			{
-				song.Save(new Uri("song:///" + dlg.Filename));
+				song.Save(new Uri("song:///" + Uri.EscapeDataString(dlg.Filename)));
 			}
 		}
 

--- a/WordsLive/Editor/EditorWindow.xaml.cs
+++ b/WordsLive/Editor/EditorWindow.xaml.cs
@@ -212,7 +212,7 @@ namespace WordsLive.Editor
 
 			if (dlg.ShowDialog() == true)
 			{
-				song.Save(new Uri("song:///" + Uri.EscapeDataString(dlg.Filename)));
+				song.Save(SongUri.GetUri(dlg.Filename));
 			}
 		}
 

--- a/WordsLive/MediaOrderList/MediaOrderItem.cs
+++ b/WordsLive/MediaOrderList/MediaOrderItem.cs
@@ -21,6 +21,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Media;
 using WordsLive.Core;
+using WordsLive.Core.Songs.Storage;
 
 namespace WordsLive.MediaOrderList
 {
@@ -75,7 +76,7 @@ namespace WordsLive.MediaOrderList
 				}
 				else if (Data.Uri.Scheme == "song")
 				{
-					return Uri.UnescapeDataString(Data.Uri.AbsolutePath).Substring(1);
+					return SongUri.GetFilename(Data.Uri);
 				}
 				else
 				{


### PR DESCRIPTION
When song file names use characters that need to be escaped in URIs, then there can be problems. An example is the character `#` that is automatically removed with everything behind it.
* internal representation of `song://` URIs needs escaped file names (this was inconsistent so far)
* in the `.ppp` portfolio files, the file name is stored unescaped (as before)