### PR TITLE
Hide presenter view in PowerPoint presentations

### DIFF
--- a/WordsLive.Slideshow.Powerpoint.Bridge/PowerpointPresentation.cs
+++ b/WordsLive.Slideshow.Powerpoint.Bridge/PowerpointPresentation.cs
@@ -83,6 +83,7 @@ namespace WordsLive.Slideshow.Powerpoint.Bridge
 				this.application.SlideShowNextSlide += application_SlideShowNextSlide;
 				this.application.SlideShowEnd += application_SlideShowEnd;
 
+				this.presentation.SlideShowSettings.ShowPresenterView = MsoTriState.msoFalse;
 				this.presentation.SlideShowSettings.Run();
 				this.presentation.SlideShowWindow.Top = OUTSIDE_Y; // outside of screen (-> hidden)
 				this.presentation.SlideShowWindow.Left = PixelsToPoints(Area.WindowLocation.X);


### PR DESCRIPTION
Because we use WordsLive to control the PowerPoint presentation, I think it is safe to prevent the presenter view explicitly. (At least on my Office 2024 at home, the presenter view appears by default - and this is full screen above WordsLive.)